### PR TITLE
chore(properties): add min length validation on properties

### DIFF
--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -44,11 +44,11 @@ export const schemaFormSchema = z.object({
   name: z.string({ required_error: 'Schema Name required' }),
   properties: z.array(
     z.object({
-      name: z.string({ required_error: 'Properties Name required' }),
-      type: z.string({ required_error: 'Type required' }),
+      name: z.string().min(1, { message: 'Properties Name required' }),
+      type: z.string().min(1, { message: 'Type required' }),
       example: z.string().optional(),
     })
-  ),
+  ).min(1),
 });
 
 export const pathFormSchema = z.object({


### PR DESCRIPTION
Previously we allow user to save a schema without any properties submitted. This PR is raised to add validation on `properties` array to become required at least 1 element needed to submit